### PR TITLE
Avoid -Werror=comment issue with gcc

### DIFF
--- a/include/detria.hpp
+++ b/include/detria.hpp
@@ -2146,15 +2146,16 @@ namespace detria
 
             inline void flipEdge(HalfEdgeIndex edgeIndex)
             {
-                //      0                 0
-                //      *                 *
-                //     /|\               / \
-                //    / | \             /   \
-                // 3 *  |  * 1  -->  3 *-----* 1
-                //    \ | /             \   /
-                //     \|/               \ /
-                //      *                 *
-                //      2                 2
+                /*        0                 0
+                 *        *                 *
+                 *       /|\               / \
+                 *      / | \             /   \
+                 *   3 *  |  * 1  -->  3 *-----* 1
+                 *      \ | /             \   /
+                 *       \|/               \ /
+                 *        *                 *
+                 *        2                 2
+		 */
 
                 // Setup all references
                 HalfEdge& edge = getEdge(edgeIndex);


### PR DESCRIPTION
Use C-style commenting to avoid the following warning from gcc:

detria.hpp:2151:17: error: multi-line comment [-Werror=comment]
 2151 |                 //     /|\               / \
      |                 ^